### PR TITLE
Fix JENKINS-70842 by adding a depency.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,5 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
-
+buildPlugin(
+  configurations: [
+    [platform: 'linux', jdk: 11],
+    [platform: 'windows', jdk: 11],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.level>8</java.level>
     <jenkins.version>2.303.3</jenkins.version>
+    <apache-httpcomponents-client-4-api.version>4.5.14-150.v7a_b_9d17134a_5</apache-httpcomponents-client-4-api.version>
   </properties>
 
   <developers>
@@ -89,6 +90,11 @@
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
+      <version>${apache-httpcomponents-client-4-api.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.10</version>
+      <version>3.0.16</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.37</version>
+        <version>4.54</version>
         <relativePath />
     </parent>
   <artifactId>global-post-script</artifactId>
-  <version>1.1.5-SNAPSHOT</version>
+  <version>1.1.6-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Global+Post+Script+Plugin</url>
@@ -23,8 +23,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.level>8</java.level>
-    <jenkins.version>2.303.3</jenkins.version>
+    <jenkins.version>2.375.2</jenkins.version>
   </properties>
 
   <developers>
@@ -65,7 +64,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5</version>
         <configuration>
           <goals>deploy</goals>
         </configuration>

--- a/src/main/java/com/orctom/jenkins/plugin/globalpostscript/GlobalPostScript.java
+++ b/src/main/java/com/orctom/jenkins/plugin/globalpostscript/GlobalPostScript.java
@@ -54,7 +54,7 @@ public class GlobalPostScript extends RunListener<Run<?, ?>> implements Describa
     }
 
     String script = getDescriptorImpl().getScript();
-    File file = new File(Jenkins.getInstance().getRootDir().getAbsolutePath() + SCRIPT_FOLDER, script);
+    File file = new File(Jenkins.get().getRootDir().getAbsolutePath() + SCRIPT_FOLDER, script);
     if (file.exists()) {
       try {
         BadgeManager manager = new BadgeManager(run, listener);
@@ -83,7 +83,7 @@ public class GlobalPostScript extends RunListener<Run<?, ?>> implements Describa
   }
 
   public DescriptorImpl getDescriptorImpl() {
-    return (DescriptorImpl) Jenkins.getInstance().getDescriptorOrDie(GlobalPostScript.class);
+    return (DescriptorImpl) Jenkins.get().getDescriptorOrDie(GlobalPostScript.class);
   }
 
   @SuppressWarnings("unchecked")
@@ -141,11 +141,11 @@ public class GlobalPostScript extends RunListener<Run<?, ?>> implements Describa
       for (Map.Entry<String, String> entry : params.entrySet()) {
         newParams.add(new StringParameterValue(entry.getKey(), entry.getValue()));
       }
-      AbstractProject job = Jenkins.getInstance().getItem(jobName, run.getParent().getParent(), AbstractProject.class);
+      AbstractProject job = Jenkins.get().getItem(jobName, run.getParent().getParent(), AbstractProject.class);
       if (null != job) {
         Cause cause = new Cause.UpstreamCause(run);
         boolean scheduled = job.scheduleBuild(job.getQuietPeriod(), cause, new ParametersAction(newParams));
-        if (Jenkins.getInstance().getItemByFullName(job.getFullName()) == job) {
+        if (Jenkins.get().getItemByFullName(job.getFullName()) == job) {
           String name = ModelHyperlinkNote.encodeTo(job) + "  "
               + ModelHyperlinkNote.encodeTo(
               job.getAbsoluteUrl() + job.getNextBuildNumber() + "/",
@@ -201,7 +201,7 @@ public class GlobalPostScript extends RunListener<Run<?, ?>> implements Describa
         }
       }
 
-      String rootUrl = Jenkins.getInstance().getRootUrl();
+      String rootUrl = Jenkins.get().getRootUrl();
       if (StringUtils.isNotEmpty(rootUrl)) {
         cause.append("on ").append(rootUrl).append(" ");
       }
@@ -226,6 +226,7 @@ public class GlobalPostScript extends RunListener<Run<?, ?>> implements Describa
     }
 
     public FormValidation doCheckScript(@QueryParameter("script") String name) throws IOException, ServletException {
+      Jenkins.get().checkPermission(Jenkins.ADMINISTER);
       if (StringUtils.isEmpty(name)) {
         return FormValidation.error("Please set the script name");
       }
@@ -238,7 +239,7 @@ public class GlobalPostScript extends RunListener<Run<?, ?>> implements Describa
     public ComboBoxModel doFillScriptItems() {
       ComboBoxModel items = new ComboBoxModel();
 
-      File scriptFolder = new File(Jenkins.getInstance().getRootDir().getAbsolutePath() + SCRIPT_FOLDER);
+      File scriptFolder = new File(Jenkins.get().getRootDir().getAbsolutePath() + SCRIPT_FOLDER);
       FilenameFilter filter = new FilenameFilter() {
         public boolean accept(File dir, String name) {
           String fileName = name.toLowerCase();

--- a/src/main/java/com/orctom/jenkins/plugin/globalpostscript/GlobalPostScriptAction.java
+++ b/src/main/java/com/orctom/jenkins/plugin/globalpostscript/GlobalPostScriptAction.java
@@ -33,7 +33,7 @@ public class GlobalPostScriptAction implements BuildBadgeAction {
       return null;
     }
 
-    PluginWrapper wrapper = Jenkins.getInstance().getPluginManager().getPlugin(GlobalPostScriptPlugin.class);
+    PluginWrapper wrapper = Jenkins.get().getPluginManager().getPlugin(GlobalPostScriptPlugin.class);
     boolean pluginIconExists = (wrapper != null) && new File(wrapper.baseResourceURL.getPath() + "/img/" + icon).exists();
     return pluginIconExists ? "/plugin/global-post-script/img/" + icon : Jenkins.RESOURCE_PATH + "/images/16x16/" + icon;
   }

--- a/src/main/java/com/orctom/jenkins/plugin/globalpostscript/runner/GroovyScriptRunner.java
+++ b/src/main/java/com/orctom/jenkins/plugin/globalpostscript/runner/GroovyScriptRunner.java
@@ -42,11 +42,14 @@ public class GroovyScriptRunner extends ScriptRunner {
   }
 
   protected ClassLoader getGroovyClassloader() {
-    if (null == Jenkins.getInstance()) {
+    try {
+      Jenkins.get();
+    }
+    catch (IllegalStateException e){
       return getParentClassloader();
     }
-
-    File libFolder = new File(Jenkins.getInstance().getRootDir().getAbsolutePath() + GlobalPostScript.SCRIPT_FOLDER, "lib");
+    
+    File libFolder = new File(Jenkins.get().getRootDir().getAbsolutePath() + GlobalPostScript.SCRIPT_FOLDER, "lib");
     return getGroovyClassloader(libFolder);
   }
 

--- a/src/main/java/com/orctom/jenkins/plugin/globalpostscript/runner/ScriptRunner.java
+++ b/src/main/java/com/orctom/jenkins/plugin/globalpostscript/runner/ScriptRunner.java
@@ -1,7 +1,6 @@
 package com.orctom.jenkins.plugin.globalpostscript.runner;
 
 import com.orctom.jenkins.plugin.globalpostscript.GlobalPostScript;
-import groovy.lang.GroovyClassLoader;
 import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
 
@@ -24,9 +23,10 @@ public abstract class ScriptRunner {
   }
 
   protected ClassLoader getParentClassloader() {
-    if (null != Jenkins.getInstance()) {
-      return Jenkins.getInstance().getPluginManager().uberClassLoader;
-    } else {
+    try {
+      return Jenkins.get().getPluginManager().uberClassLoader;
+    }
+    catch (IllegalStateException e){
       return Thread.currentThread().getContextClassLoader();
     }
   }


### PR DESCRIPTION
This PR fixes JENKINS-70842 by explicitly adding a dependency on the https://plugins.jenkins.io/apache-httpcomponents-client-4-api plugin and updating the plugin code that makes the HTTP request to work with the updated libraries.